### PR TITLE
Update 2019-11-01-Tekton-Enterprise-CI-CD.adoc

### DIFF
--- a/drafts/2019-11-01-Tekton-Enterprise-CI-CD.adoc
+++ b/drafts/2019-11-01-Tekton-Enterprise-CI-CD.adoc
@@ -10,8 +10,8 @@ additional_authors:
    github: https://github.com/jduimovich
    image: https://avatars1.githubusercontent.com/u/7844190?s=400&v=4
 seo-title: How Tekton can power your Enterprise’s continuous integration & continuous delivery
-seo-description: Read about Tekton - a new open source project that provides a framework for creating cloud native CI/CD pipelines.
-blog_description: "Read about Tekton - a new open source project that provides a framework for creating cloud native CI/CD pipelines."
+seo-description: Read about Tekton pipelines in Kabanero, powering enterprise's continuous integration & continuous delivery needs on Kubernetes
+blog_description: "Read about Tekton pipelines in Kabanero, powering enterprise's continuous integration & continuous delivery needs on Kubernetes."
 ---
 
 Accelerating application delivery is vital for today’s companies as they address market demands. The ability to create new applications quickly and then deploy, manage, and scale these applications is one of the key factors driving cloud adoption. As developers move to cloud, automation of end-to-end processes is a core component of success. This automation typically comes by embracing DevOps, and the adoption of continuous integration (CI) and continuous delivery (CD) as the key to this growth. CI and CD processes can build, deploy, and validate changes in a seamless and programmatic way, enabling developers to reliably integrate and quickly deploy new features in their applications.
@@ -22,18 +22,20 @@ There are many existing CI/CD tools that developers use to build and/or deploy t
 
 What does it mean to be cloud native and why is it important? Cloud native tools are purpose-built for the cloud. They take advantage of access to instantly available compute and storage resources that can be adapted quickly to the needs of the tool. Cloud native tools also offer simplified maintenance, resiliency, and elasticity, which gives you the ability to scale resources as needed.
 
-Introducing Tekton, a new open source project that provides a framework for creating cloud native CI/CD pipelines. Tekton benefits from a robust community of contributors and provides a set of fundamental building blocks for creating a CI/CD environment. Tekton provides a first-class Kubernetes integration, including custom resource definitions (CRDs) as a standard way to run end-to-end pipelines. 
+== Introducing Tekton 
+
+Tekton is an open source project in the Continuous Delivery Foundation that provides a framework for creating cloud native CI/CD pipelines on Kubernetes. Tekton benefits from a robust community of contributors and provides a set of fundamental building blocks for creating a CI/CD environment. Tekton provides a first-class Kubernetes integration, including custom resource definitions (CRDs) as a standard way to run end-to-end pipelines. 
 
 Each Tekton pipeline is made up of a sequence of tasks. For example, tasks could include a Git clone, a build, a vulnerability scan, running tests, or deploying the application. These tasks can be as simple or complex as needed. Tasks are tied together to make up a pipeline and can be run sequentially, concurrently, or on different nodes. Developers can create new tasks and share them across their enterprise by putting task containers into a container registry and consuming these containers in Tekton Tasks. This basic use case shows how leveraging a cloud native approach can simplify tool distribution across CI/CD systems and have an instant worldwide distribution of this new tool. Teams no longer need to reinstall existing tools across all your build and test servers for build agents to use. With a cloud native approach, teams can use this distribution mechanism to deliver and update tools across the organization. 
 
 An integrated CI/CD system also enables operations processes to be reliably automated. Operations activities like applying patches, security fixes, and maintenance can leverage the integrated CI system to provide updated containers for deployment.
 
-A sample Tekton pipeline: 
+== A sample Tekton pipeline
 
 image::/img/blog/Tekton-Intro.png[link="/img/blogs/Tekton-Intro.png" alt="Tekton Intro"]
 
-
-While Tekton is still new, the community of innovators that are contributing to and using Tekton is growing. Through layered steps and tasks, Tekton pipelines give flexibility to enterprises for their continuous integration and delivery needs. Tekton pipelines also allow enterprises to meet their customer demands by quickly delivering vital application updates that satisfy enterprise-specific quality and security requirements. 
-
+== Summary
+Through layered steps and tasks, Tekton pipelines give flexibility to enterprises for their continuous integration and delivery needs on Kubernetes. Tekton pipelines also allow enterprises to meet their customer demands by quickly delivering vital application updates that satisfy enterprise-specific quality and security requirements for cloud native applications. 
  
-To see Tekton in action, go to the link:https://kabanero.io/[Kabanero website]. Kabanero brings together Knative, Istio, and Tekton, with Codewind and Appsody. Together, these open source projects provide an end-to-end solution for you to build, deploy, and manage the lifecycle of Kubernetes-based applications. 
+== Learn More
+Kabanero provides pre-built pipelines and tasks using Tekton. You can read more about Tekton pipelines in Kabanero, which provides a modern DevOps Toolchain for Kubernetes with cloud native CI/CD pipelines. You can learn more about the architecture of Kabanero and the modern DevOps Toolchain that's provided from our link:https://kabanero.io/guides/[Guides] section.  


### PR DESCRIPTION
Nate's edits adding section headings and updating the ending to not reference going to Kabanero.io when you are in fact on Kabanero.io reading the blog.

part of #15 